### PR TITLE
feat(monitoring): implement servicemonitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ These steps guide you through setting up the Kubernetes cluster on your local ma
     ```
     This will remove all the VMs and the Kubernetes cluster.
 
+## Kubernetes Cluster Monitoring (Assignment 3)
+
+Check [README.md](./kubernetes/helm/sentiment-analysis/README.md) in the `kubernetes/helm/sentiment-analysis` directory for instructions on how to set up monitoring for the application using Prometheus and Grafana.
+
 ## Known Bug: Port Conflict on macOS (AirPlay Receiver)
 
 On macOS, the `app-service` currently binds statically to `localhost:5000`. However, macOS reserves port `5000` for the AirPlay Receiver feature by default. This causes the app-service to fail to start or bind to the port correctly during local development or testing. 

--- a/kubernetes/docker-compose.yml
+++ b/kubernetes/docker-compose.yml
@@ -1,14 +1,14 @@
 services:
   app-frontend:
     container_name: app-frontend
-    build: "../../app/app-frontend"
-    #image: ghcr.io/remla25-team21/app-frontend
+    # build: "../../app/app-frontend"
+    image: ghcr.io/remla25-team21/app-frontend
     ports:
       - 3000:3000
 
   app-service:
-    build: "../../app/app-service"
-    #image: ghcr.io/remla25-team21/app-backend
+    # build: "../../app/app-service"
+    image: ghcr.io/remla25-team21/app-backend
     ports:
       - 5000:5000
     environment:
@@ -18,9 +18,9 @@ services:
         condition: service_healthy
 
   model-service:
-    build: "../../model-service"
+    # build: "../../model-service"
     container_name: model-service
-    #image: ghcr.io/remla25-team21/model-service
+    image: ghcr.io/remla25-team21/model-service
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080"]
       interval: 30s

--- a/kubernetes/helm/sentiment-analysis/README.md
+++ b/kubernetes/helm/sentiment-analysis/README.md
@@ -9,8 +9,8 @@ This Helm chart deploys the Restaurant Review Sentiment Analysis application, wh
 >
 > ```bash
 > helm install my-sentiment-analysis ./kubernetes/helm/sentiment-analysis
-> kubectl port-forward svc/app-frontend 3000:3000  # Keep this running in a separate terminal
-> kubectl port-forward service/app-service 5000:5000  # Keep this running in another terminal
+> kubectl port-forward svc/my-sentiment-analysis-app-frontend 3000:3000  # Keep this running in a separate terminal
+> kubectl port-forward svc/my-sentiment-analysis-app-service 5000:5000  # Keep this running in another terminal
 > ```
 >
 > 2. Start prometheus and Grafana to monitor the application:
@@ -19,7 +19,7 @@ This Helm chart deploys the Restaurant Review Sentiment Analysis application, wh
 > helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 > helm repo update
 > helm install prometheus prometheus-community/kube-prometheus-stack
-> kubectl port-forward service/prometheus-operated 9090:9090  # Keep this running in a separate terminal
+> kubectl port-forward svc/prometheus-operated 9090:9090  # Keep this running in a separate terminal
 > ```
 >
 > 3. Access the application at `http://localhost:3000` and Prometheus at `http://localhost:9090`.
@@ -36,11 +36,11 @@ This Helm chart deploys the Restaurant Review Sentiment Analysis application, wh
 4. You can check if you've successfully installed your Helm release. (e.g., `helm status my-sentiment-analysis` to check the status of release, `kubectl get pods` to check that the pods are running, `kubectl get svc` to check for services, `kubectl get ingress` to check for ingress etc)
 5. You can port-forward the frontend service to your local machine like this:
    ```bash
-   kubectl port-forward svc/app-frontend 3000:3000
+   kubectl port-forward svc/my-sentiment-analysis-app-frontend 3000:3000
    ```
 6. You also have to port-forward the backend service for it to be reachable from the frontend accessed via localhost
    ```bash
-   kubectl port-forward service/app-service 5000:5000
+   kubectl port-forward svc/my-sentiment-analysis-app-service 5000:5000
    ```
 7. Access the application from `http://localhost:3000`.
 
@@ -92,7 +92,7 @@ Then visit `http://localhost:5000/metrics` in your browser.
 4. To access the Prometheus dashboard, you can port-forward the Prometheus service:
 
    ```bash
-   kubectl port-forward service/prometheus-operated 9090:9090
+   kubectl port-forward svc/prometheus-operated 9090:9090
    ```
 
    Then visit `http://localhost:9090` in your browser and query for the metrics like:

--- a/kubernetes/helm/sentiment-analysis/README.md
+++ b/kubernetes/helm/sentiment-analysis/README.md
@@ -19,4 +19,64 @@ This Helm chart deploys the Restaurant Review Sentiment Analysis application, wh
    ```bash
    kubectl port-forward service/app-service 5000:5000
    ```
-6. Access the application from `http://localhost:3000`.
+7. Access the application from `http://localhost:3000`.
+
+## Prometheus Monitoring
+
+The app-service includes built-in Prometheus metrics to monitor application usage and performance. A ServiceMonitor resource is deployed alongside the application to enable automatic metrics scraping by Prometheus.
+
+### Available Metrics
+
+1. **sentiment_predictions_total** (Counter)
+   - Tracks the total number of sentiment predictions made
+   - Includes labels to differentiate between positive and negative sentiments
+   
+2. **sentiment_positive_ratio** (Gauge)
+   - Measures the ratio of positive to total sentiments (value between 0-1)
+   
+3. **sentiment_prediction_latency_seconds** (Histogram)
+   - Tracks the time taken to process sentiment predictions
+   - Includes multiple buckets to categorize response times
+   
+### Accessing Metrics
+
+You can access the metrics directly by port-forwarding the app-service and visiting the metrics endpoint:
+
+```bash
+kubectl port-forward service/app-service 5000:5000
+```
+
+Then visit `http://localhost:5000/metrics` in your browser.
+
+### Setting Up Prometheus
+
+1. Make sure you have the Prometheus Operator installed in your cluster. If you don't have it installed, you can use the kube-prometheus-stack Helm chart:
+
+   ```bash
+   helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+   helm repo update
+   helm install prometheus prometheus-community/kube-prometheus-stack
+   ```
+
+2. The ServiceMonitor included in this chart is configured to be automatically discovered by Prometheus, as long as your Prometheus instance is configured to discover ServiceMonitors in this namespace.
+
+3. You can check if the ServiceMonitor is working by running:
+
+   ```bash
+   kubectl get servicemonitors
+   ```
+
+4. To access the Prometheus dashboard, you can port-forward the Prometheus service:
+
+   ```bash
+   kubectl port-forward service/prometheus-operated 9090:9090
+   ```
+
+   Then visit `http://localhost:9090` in your browser and query for the metrics like:
+   - `sentiment_predictions_total`
+   - `sentiment_positive_ratio`
+   - `sentiment_prediction_latency_seconds_bucket`
+
+### Grafana Dashboard
+
+// TODO

--- a/kubernetes/helm/sentiment-analysis/README.md
+++ b/kubernetes/helm/sentiment-analysis/README.md
@@ -2,6 +2,29 @@
 
 This Helm chart deploys the Restaurant Review Sentiment Analysis application, which includes a model service for sentiment analysis and a web application frontend/backend.
 
+> [!NOTE]
+> TL;DR:
+>
+> 1. Run the following command to install the chart and access the application:
+>
+> ```bash
+> helm install my-sentiment-analysis ./kubernetes/helm/sentiment-analysis
+> kubectl port-forward svc/app-frontend 3000:3000  # Keep this running in a separate terminal
+> kubectl port-forward service/app-service 5000:5000  # Keep this running in another terminal
+> ```
+>
+> 2. Start prometheus and Grafana to monitor the application:
+>
+> ```bash
+> helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+> helm repo update
+> helm install prometheus prometheus-community/kube-prometheus-stack
+> kubectl port-forward service/prometheus-operated 9090:9090  # Keep this running in a separate terminal
+> ```
+>
+> 3. Access the application at `http://localhost:3000` and Prometheus at `http://localhost:9090`.
+> 4. For Grafana, ...
+
 ## Installation
 
 1. First, ensure you have your Kubernetes cluster running (e.g., with `minikube start`)

--- a/kubernetes/helm/sentiment-analysis/templates/app-configmap.yaml
+++ b/kubernetes/helm/sentiment-analysis/templates/app-configmap.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ .Release.Name }}-app-configmap
 data:
   {{- range $key, $value := .Values.configMap.data }}
+  {{- if eq $key "MODEL_SERVICE_URL" }}
+  MODEL_SERVICE_URL: "http://{{ $.Release.Name }}-{{ $.Values.modelService.name }}:{{ $.Values.modelService.service.port }}"
+  {{- else }}
   {{ $key }}: "{{ $value }}"
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/kubernetes/helm/sentiment-analysis/templates/app-service.yaml
+++ b/kubernetes/helm/sentiment-analysis/templates/app-service.yaml
@@ -22,9 +22,11 @@ spec:
       containers:
       - name: {{ .Values.appService.name }}
         image: {{ .Values.appService.image.repository }}:{{ .Values.appService.image.tag }}
+        imagePullPolicy: {{ .Values.appService.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.appService.service.port }}
           name: http
+          protocol: TCP
         envFrom:
           - configMapRef:
               name: app-configmap 
@@ -43,6 +45,10 @@ metadata:
   name: {{ .Values.appService.name }}
   labels:
     app: {{ .Values.appService.name }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: "/metrics"
+    prometheus.io/port: "{{ .Values.appService.service.port }}"
 spec:
   selector:
     app: {{ .Values.appService.name }}
@@ -50,5 +56,6 @@ spec:
     - port: {{ .Values.appService.service.port }}
       targetPort: {{ .Values.appService.service.port }}
       name: http
+      protocol: TCP
   type: {{ .Values.appService.service.type }}
 

--- a/kubernetes/helm/sentiment-analysis/templates/app-service.yaml
+++ b/kubernetes/helm/sentiment-analysis/templates/app-service.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.appService.name }}
+  labels:
+    app: {{ .Values.appService.name }}
 spec:
   replicas: {{ .Values.appService.replicaCount }}
   selector:
@@ -12,12 +14,17 @@ spec:
     metadata:
       labels:
         app: {{ .Values.appService.name }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "{{ .Values.appService.service.port }}"
     spec:
       containers:
       - name: {{ .Values.appService.name }}
         image: {{ .Values.appService.image.repository }}:{{ .Values.appService.image.tag }}
         ports:
         - containerPort: {{ .Values.appService.service.port }}
+          name: http
         envFrom:
           - configMapRef:
               name: app-configmap 
@@ -34,11 +41,14 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.appService.name }}
+  labels:
+    app: {{ .Values.appService.name }}
 spec:
   selector:
     app: {{ .Values.appService.name }}
   ports:
     - port: {{ .Values.appService.service.port }}
       targetPort: {{ .Values.appService.service.port }}
+      name: http
   type: {{ .Values.appService.service.type }}
 

--- a/kubernetes/helm/sentiment-analysis/templates/app-service.yaml
+++ b/kubernetes/helm/sentiment-analysis/templates/app-service.yaml
@@ -2,9 +2,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.appService.name }}
+  name: {{ .Release.Name }}-{{ .Values.appService.name }}
   labels:
-    app: {{ .Values.appService.name }}
+    app: {{ .Release.Name }}-{{ .Values.appService.name }}
 spec:
   replicas: {{ .Values.appService.replicaCount }}
   selector:
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ .Values.appService.name }}
+        app: {{ .Release.Name }}-{{ .Values.appService.name }}
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
@@ -42,9 +42,9 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.appService.name }}
+  name: {{ .Release.Name }}-{{ .Values.appService.name }}
   labels:
-    app: {{ .Values.appService.name }}
+    app: {{ .Release.Name }}-{{ .Values.appService.name }}
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/path: "/metrics"

--- a/kubernetes/helm/sentiment-analysis/templates/servicemonitor.yaml
+++ b/kubernetes/helm/sentiment-analysis/templates/servicemonitor.yaml
@@ -1,18 +1,17 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Values.appService.name }}-monitor
+  name: {{ .Release.Name }}-{{ .Values.appService.name }}-monitor
   labels:
-    app: {{ .Values.appService.name }}
+    app: {{ .Release.Name }}-{{ .Values.appService.name }}
     release: prometheus
-    k8s-app: {{ .Values.appService.name }}
     {{- with .Values.monitoring.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   selector:
     matchLabels:
-      app: {{ .Values.appService.name }}
+      app: {{ .Release.Name }}-{{ .Values.appService.name }}
   endpoints:
   - port: http
     path: /metrics

--- a/kubernetes/helm/sentiment-analysis/templates/servicemonitor.yaml
+++ b/kubernetes/helm/sentiment-analysis/templates/servicemonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.appService.name }}-monitor
+  labels:
+    app: {{ .Values.appService.name }}
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Values.appService.name }}
+  endpoints:
+  - port: http
+    path: /metrics
+    interval: 1s  # FIXME: For debugging purposes, set to 1s. Change to 30s for production.

--- a/kubernetes/helm/sentiment-analysis/templates/servicemonitor.yaml
+++ b/kubernetes/helm/sentiment-analysis/templates/servicemonitor.yaml
@@ -4,7 +4,11 @@ metadata:
   name: {{ .Values.appService.name }}-monitor
   labels:
     app: {{ .Values.appService.name }}
-    release: {{ .Release.Name }}
+    release: prometheus
+    k8s-app: {{ .Values.appService.name }}
+    {{- with .Values.monitoring.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
@@ -12,4 +16,7 @@ spec:
   endpoints:
   - port: http
     path: /metrics
-    interval: 1s  # FIXME: For debugging purposes, set to 1s. Change to 30s for production.
+    interval: 15s
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}

--- a/kubernetes/helm/sentiment-analysis/values.yaml
+++ b/kubernetes/helm/sentiment-analysis/values.yaml
@@ -50,3 +50,7 @@ configMap:
   create: true
   data:
     MODEL_SERVICE_URL: "http://model-service:8080"
+
+# Prometheus monitoring configuration
+monitoring:
+  enabled: true

--- a/kubernetes/helm/sentiment-analysis/values.yaml
+++ b/kubernetes/helm/sentiment-analysis/values.yaml
@@ -58,6 +58,7 @@ monitoring:
     enabled: true
     additionalLabels:
       prometheus: kube-prometheus
+
 # Secret configuration (just to show that I know how to)
 secret:
   create: true

--- a/kubernetes/helm/sentiment-analysis/values.yaml
+++ b/kubernetes/helm/sentiment-analysis/values.yaml
@@ -54,3 +54,7 @@ configMap:
 # Prometheus monitoring configuration
 monitoring:
   enabled: true
+  serviceMonitor:
+    enabled: true
+    additionalLabels:
+      prometheus: kube-prometheus


### PR DESCRIPTION
Implement three backend metrics with Prometheus Monitoring. (Check PR in app repo: https://github.com/remla25-team21/app/pull/13)

1. **sentiment_predictions_total** (Counter)
   - Tracks the total number of sentiment predictions made
   - Includes labels to differentiate between positive and negative sentiments
   
2. **sentiment_positive_ratio** (Gauge)
   - Measures the ratio of positive to total sentiments (value between 0-1)
   
3. **sentiment_prediction_latency_seconds** (Histogram)
   - Tracks the time taken to process sentiment predictions
   - Includes multiple buckets to categorize response times

**TODO**: 
1. Alerting
2. Instructions needed for deployment on the clusters from a2